### PR TITLE
Adding launch argument for yaml configuration file

### DIFF
--- a/src/hexapod_bringup/launch/all_local_debug.launch
+++ b/src/hexapod_bringup/launch/all_local_debug.launch
@@ -2,8 +2,10 @@
 <!-- Full bringup local launch file ( for example if you remote logged into the robot ) -->
 
 <launch>
-    <include file="$(find hexapod_bringup)/launch/hexapod_full.launch" />
+    <arg name="config" default="hexapod"/>
+    <include file="$(find hexapod_bringup)/launch/hexapod_full.launch">
+      <arg name="config" value="$(arg config)"/>
+    </include>
 <!--    <include file="$(find hexapod_bringup)/launch/visualize_rtabmap.launch" /> -->
     <include file="$(find hexapod_bringup)/launch/rviz.launch" />
 </launch>
-

--- a/src/hexapod_bringup/launch/hexapod_full.launch
+++ b/src/hexapod_bringup/launch/hexapod_full.launch
@@ -2,12 +2,14 @@
 <!-- Full bringup no visual nodes launch file ( Normal use, visual ran on remote desktop ) -->
 
 <launch>
+    <arg name="config" default="hexapod"/>
     <!-- Launching sound first since some packages have initial sounds -->
     <include file="$(find hexapod_bringup)/launch/components/sounds.launch" />
-    <include file="$(find hexapod_bringup)/launch/hexapod_simple.launch" />
+    <include file="$(find hexapod_bringup)/launch/hexapod_simple.launch">
+      <arg name="config" value="$(arg config)"/>
+    </include>
     <include file="$(find hexapod_bringup)/launch/components/imu_phidgets.launch" />
     <include file="$(find hexapod_bringup)/launch/components/depth_laserscan.launch" />
     <include file="$(find hexapod_bringup)/launch/components/robot_localization_ekf.launch" />
     <include file="$(find hexapod_bringup)/launch/components/rtabmap.launch" />
 </launch>
-

--- a/src/hexapod_bringup/launch/hexapod_simple.launch
+++ b/src/hexapod_bringup/launch/hexapod_simple.launch
@@ -2,9 +2,9 @@
 <!-- Minimal bringup - just locomotion and joy teleop no visual nodes launch file ( Normal use, visual ran on remote desktop ) -->
 
 <launch>
-    <rosparam command="load" file="$(find hexapod_description)/params/hexapod.yaml" />
+    <arg name="config" default="hexapod"/>
+    <rosparam command="load" file="$(find hexapod_description)/params/$(arg config).yaml" />
     <param name="robot_description" command="$(find xacro)/xacro.py '$(find hexapod_description)/urdf/hexapod_model.xacro'" />
     <include file="$(find hexapod_bringup)/launch/components/joy_teleop.launch" />
     <include file="$(find hexapod_bringup)/launch/components/locomotion.launch" />
 </launch>
-


### PR DESCRIPTION
This pull request adds a launch argument for the yaml configuration file. Check it by running:

```
roslaunch hexapod_bringup hexapod_full.launch config:=yaml_file
```

and

```
roslaunch hexapod_bringup all_local_debug.launch config:=yaml_file
```

The yaml file should be located in `hexapod_description/params` folder.
