### PR TITLE
Small C++ improvements

### DIFF
--- a/src/hexapod_locomotion/include/control.h
+++ b/src/hexapod_locomotion/include/control.h
@@ -31,7 +31,7 @@
 #ifndef CONTROL_H_
 #define CONTROL_H_
 
-#include <math.h>
+#include <cmath>
 #include <ros/ros.h>
 #include <std_srvs/Empty.h>
 #include <std_msgs/Bool.h>

--- a/src/hexapod_locomotion/src/control.cpp
+++ b/src/hexapod_locomotion/src/control.cpp
@@ -59,7 +59,7 @@ Control::Control( void )
     joint_state_.position.resize( servo_map_key_.size() );
     servo_names_.resize( servo_map_key_.size() );
     servo_orientation_.resize( servo_map_key_.size() );
-    for( int i = 0; i < servo_map_key_.size(); i++ )
+    for( size_t i = 0; i < servo_map_key_.size(); i++ )
     {
         ros::param::get( ("/SERVOS/" + static_cast<std::string>( servo_map_key_[i] ) + "/name"), servo_names_[i] );
         ros::param::get( ("/SERVOS/" + static_cast<std::string>( servo_map_key_[i] ) + "/sign"), servo_orientation_[i] );


### PR DESCRIPTION
- Used the C++ `cmath` header instead of the C `math.h`
- Used the `size_t` type to get the `servo_map_key_.size()` in order to avoid a compiler warning.
